### PR TITLE
fix: Allow Ubuntu version numbers to be valid

### DIFF
--- a/lib/Test/MTA/Exim4.pm
+++ b/lib/Test/MTA/Exim4.pm
@@ -711,7 +711,7 @@ sub _run_exim_bv {
         $self->{_state}{config}{ok} = 1;
         foreach ( @{$stdout_buf} ) {
             chomp;
-            if (/^Exim\s+version\s+([0-9\.]+)\s+#(\d+)/) {
+            if (/^Exim\s+version\s+([0-9\.]+)(?:_[0-9]+)?\s+#(\d+)/) {
                 $self->{_state}{exim_version} = $1;
                 $self->{_state}{exim_build}   = $2;
             }

--- a/t/scripts/fake_exim
+++ b/t/scripts/fake_exim
@@ -8,7 +8,7 @@ sub do_bv {
 
     # output the basic stuff
     print(
-        "Exim version 4.74 #1 built 25-Jan-2011 22:21:31\n",
+        "Exim version 4.74_1 #1 built 25-Jan-2011 22:21:31\n",
         "Copyright (c) University of Cambridge, 1995 - 2007\n",
         "Berkeley DB: Sleepycat Software: Berkeley DB 4.3.29: (June 16, 2006)\n",
         "Support for: crypteq iconv() IPv6 OpenSSL move_frozen_messages Content_Scanning DKIM Old_Demime\n",


### PR DESCRIPTION
Ubuntus exim adds some kind of subversion number making tests fail on
those machines:

    $ /usr/sbin/exim4 -bV
    Exim version 4.90_1 #2 built 04-Sep-2019 11:44:01
    Copyright (c) University of Cambridge, 1995 - 2017
    (c) The Exim Maintainers and contributors in ACKNOWLEDGMENTS file, 2007 - 2017
    Berkeley DB: Berkeley DB 5.3.28: (September  9, 2013)
    Support for: crypteq iconv() IPv6 PAM Perl Expand_dlfunc GnuTLS move_frozen_messages Content_Scanning DKIM DNSSEC Event OCSP PRDR PROXY SOCKS TCP_Fast_Open
    Lookups (built-in): lsearch wildlsearch nwildlsearch iplsearch cdb dbm dbmjz dbmnz dnsdb dsearch ldap ldapdn ldapm mysql nis nis0 passwd pgsql sqlite
    Authenticators: cram_md5 cyrus_sasl dovecot plaintext spa tls
    Routers: accept dnslookup ipliteral iplookup manualroute queryprogram redirect
    Transports: appendfile/maildir/mailstore/mbx autoreply lmtp pipe smtp
    Fixed never_users: 0
    Configure owner: 0:0
    Size of off_t: 8
    2020-01-05 10:51:58.882 [15064] cwd=/home/marco/DEVEL/test-exim-mx 2 args: /usr/sbin/exim4 -bV
    Configuration file is /var/lib/exim4/config.autogenerated

This patch accepts the optional subversion number.